### PR TITLE
Proposal: update tooltip for show buff option

### DIFF
--- a/settings/settings.lua
+++ b/settings/settings.lua
@@ -203,7 +203,7 @@ local function buildOptions()
         [5] = {
             type = "checkbox",
             name = AH.Format(_G.ARCHIVEHELPER_SHOW_SELECTION),
-            tooltip = AH.Format(_G.ARCHIVEHELPER_REQUIRES),
+            tooltip = AH.Format(_G.ARCHIVEHELPER_REQUIRES) .. '. ' .. AH.Format(_G.ARCHIVEHELPER_SHOW_COUNT_TOOLTIP),
             getFunc = function()
                 return AH.Vars.ShowSelection
             end,


### PR DESCRIPTION
As the feature to show selected buffs now uses data sharing, the option tooltip should warn that LibDataShare is also required.