### PR TITLE
fixes to markers detection

### DIFF
--- a/misc/markers.lua
+++ b/misc/markers.lua
@@ -84,7 +84,7 @@ local function doChecks()
     AH.CHECK_FABLED = AH.Vars.FabledCheck
     AH.CHECK_SHARDS = false
     AH.CHECK_GW = false
-    AH.FOUND_GW = false
+    AH.CHECK_FLAMESHAPER = false
 
     if (arc == 1) then
         -- no marauders in arc 1
@@ -96,8 +96,9 @@ local function doChecks()
     end
 
     if (cycle < 5 and stage == 3) then
-        -- possible fabled due to one boss, no marauders or shards
-        AH.CHECK_FABLED = true and AH.Vars.FabledCheck
+        -- possible fabled (flameshaper) due to one boss, no marauders or shards
+        AH.CHECK_FLAMESHAPER = true and AH.Vars.FabledCheck
+        AH.CHECK_FABLED = false
         AH.CHECK_MARAUDERS = false
         AH.CHECK_SHARDS = false
         AH.CHECK_GW = true and AH.Vars.GWCheck
@@ -133,7 +134,7 @@ local function find(name)
 
     for _, text in ipairs(AH.SearchText) do
         if (name:find(text, 1, true)) then
-            return true, text == gwText
+            return true
         end
     end
     return false


### PR DESCRIPTION
In find(), the test "text == gwText" seems unnecessary (gwText is already inside AH.SearchText)

While testing, during boss fight against The Warrior, flameshaper were not marked. CHECK_FLAMESHAPER was not set to true during mid-boss fights, in doChecks()

Note: if you think real fabled can appear during boss fight, you can rather use:

```
        AH.CHECK_FABLED = true and AH.Vars.FabledCheck 
        AH.CHECK_FLAMESHAPER = AH.CHECK_FABLED
```

but it could be less good for optimisation to test 2 strings rather than one, if it can be avoided